### PR TITLE
Do not double your webpack rules

### DIFF
--- a/config/webpack/webpack.dev.babel.js
+++ b/config/webpack/webpack.dev.babel.js
@@ -11,9 +11,6 @@ module.exports = {
         path: paths.outputPath,
         chunkFilename: '[name].js'
     },
-    module: {
-        rules
-    },
     performance: {
         hints: 'warning',
         maxAssetSize: 450000,

--- a/config/webpack/webpack.prod.babel.js
+++ b/config/webpack/webpack.prod.babel.js
@@ -10,9 +10,6 @@ module.exports = {
         path: paths.outputPath,
         chunkFilename: '[name].[chunkhash].js'
     },
-    module: {
-        rules
-    },
     plugins: [
         new CleanWebpackPlugin([paths.outputPath.split('/').pop()], {
             root: paths.root


### PR DESCRIPTION
Fought with this for a few hours, when doing the webpack merge, if you specify the rules in the common file as well as in the environment specific webpack file, merging the two will double the entries instead of intelligently noting that they are the same entries. (Noticed this when trying to implement my own .css file with css-loader and style-loader.) 

Also: Thank you for making this boilerplate! I'm using it in a react demo that I'm making! 
https://github.com/ultamatt/wrestling_cards