### PR TITLE
chore: add rule for loading scss and sass

### DIFF
--- a/config/webpack/rules.js
+++ b/config/webpack/rules.js
@@ -24,5 +24,27 @@ module.exports = [
     {
         test: /\.(jpe?g|png|gif|svg)$/i,
         use: ['url-loader?limit=10000', 'img-loader']
-    }
+    },
+    {
+        test: /\.s(a|c)ss$/,
+        use: [
+            {
+                loader: 'style-loader',
+            },
+            {
+                loader: 'css-loader',
+                query: {
+                    modules: true,
+                    localIdentName: '[name]__[local]___[hash:base64:5]',
+                },
+            },
+            {
+                loader: 'sass-loader',
+                query: {
+                    modules: true,
+                    localIdentName: '[name]__[local]___[hash:base64:5]',
+                },
+            },
+        ],
+    },
 ];


### PR DESCRIPTION
@leonardomso while following tutorial for setting up the boilerplate, I realised that importing the SCSS files wasn't possible since the proper loaders were not in the `rules.js`

Added the loaders in `rules` and seems to be importing the scss/sass properly

@leonardomso great work