### PR TITLE
Add rule for loading css

### DIFF
--- a/config/webpack/rules.js
+++ b/config/webpack/rules.js
@@ -26,6 +26,17 @@ module.exports = [
         use: ['url-loader?limit=10000', 'img-loader']
     },
     {
+        test: /\.css$/,
+        use: [
+            {
+                loader: 'style-loader',
+            },
+            {
+                loader: 'css-loader',
+            },
+        ]
+    },
+    {
         test: /\.s(a|c)ss$/,
         use: [
             {


### PR DESCRIPTION
Add a rule to load the css files.
Some node packages might have css files and without the rule they will not work as expected.